### PR TITLE
Use volume for grafana data

### DIFF
--- a/docker-compose/compose.yaml
+++ b/docker-compose/compose.yaml
@@ -33,6 +33,7 @@ services:
       GF_SECURITY_ADMIN_PASSWORD: "${GRAFANA_PASSWORD}"
     volumes:
       - ./grafana:/etc/grafana/provisioning/datasources
+      - grafana_data:/var/lib/grafana
 
   ecoflow_exporter:
     image: ghcr.io/berezhinskiy/ecoflow_exporter
@@ -48,3 +49,4 @@ services:
 
 volumes:
   prom_data:
+  grafana_data:

--- a/docker-compose/compose.yaml
+++ b/docker-compose/compose.yaml
@@ -11,16 +11,16 @@ services:
       - ./prometheus:/etc/prometheus
       - prom_data:/prometheus
 
-  alertmanager:
-    image: prom/alertmanager
-    container_name: alertmanager
-    command:
-      - '--config.file=/etc/alertmanager/alertmanager.yml'
-    ports:
-      - 9093:9093
-    restart: unless-stopped
-    volumes:
-      - ./alertmanager:/etc/alertmanager
+  # alertmanager:
+  #   image: prom/alertmanager
+  #   container_name: alertmanager
+  #   command:
+  #     - '--config.file=/etc/alertmanager/alertmanager.yml'
+  #   ports:
+  #     - 9093:9093
+  #   restart: unless-stopped
+  #   volumes:
+  #     - ./alertmanager:/etc/alertmanager
 
   grafana:
     image: grafana/grafana
@@ -46,6 +46,8 @@ services:
       ECOFLOW_USERNAME: ${ECOFLOW_USERNAME}
       ECOFLOW_PASSWORD: "${ECOFLOW_PASSWORD}"
       EXPORTER_PORT: 9091
+      MQTT_TIMEOUT: 10
+      COLLECTING_INTERVAL: 5
 
 volumes:
   prom_data:

--- a/docker-compose/prometheus/prometheus.yml
+++ b/docker-compose/prometheus/prometheus.yml
@@ -1,15 +1,15 @@
 # my global config
 global:
-  scrape_interval: 10s # Set the scrape interval to every 10 seconds. Default is every 1 minute.
-  scrape_timeout: 10s
-  evaluation_interval: 10s # Evaluate rules every 10 seconds. The default is every 1 minute.
+  scrape_interval: 5s # Set the scrape interval to every 10 seconds. Default is every 1 minute.
+  scrape_timeout: 5s
+  evaluation_interval: 5s # Evaluate rules every 10 seconds. The default is every 1 minute.
 
-alerting:
-  alertmanagers:
-    - scheme: http
-      static_configs:
-        - targets:
-          - alertmanager:9093
+# alerting:
+#   alertmanagers:
+#     - scheme: http
+#       static_configs:
+#         - targets:
+#           - alertmanager:9093
 
 rule_files:
   - 'alerts/*.yml'
@@ -20,10 +20,10 @@ scrape_configs:
       - targets:
         - localhost:9090
 
-  - job_name: alertmanager
-    static_configs:
-      - targets:
-        - alertmanager:9093
+  # - job_name: alertmanager
+  #   static_configs:
+  #     - targets:
+  #       - alertmanager:9093
 
   - job_name: ecoflow
     static_configs:


### PR DESCRIPTION
Make Grafana data in container persistent. This will save dashboard changes even if the container is restarted or recreated.