### PR TITLE
Use docker volume for grafana data

### DIFF
--- a/docker-compose/compose.yaml
+++ b/docker-compose/compose.yaml
@@ -33,6 +33,7 @@ services:
       GF_SECURITY_ADMIN_PASSWORD: "${GRAFANA_PASSWORD}"
     volumes:
       - ./grafana:/etc/grafana/provisioning/datasources
+      - grafana_data:/var/lib/grafana
 
   ecoflow_exporter:
     image: ghcr.io/berezhinskiy/ecoflow_exporter
@@ -48,3 +49,4 @@ services:
 
 volumes:
   prom_data:
+  grafana_data:


### PR DESCRIPTION
Make Grafana data in container persistent. This will save dashboard changes even if the container is restarted or recreated.