### PR TITLE
Drop all non-int/float values (fixes #48)

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,12 +52,13 @@ All metrics are prefixed with `ecoflow` and reports label `device` for multiple 
 
 ⚠️ This has only been tested with the following EcoFlow products:
 
-- __River Max__
-- __River 2__
-- __River 2 Max__
-- __DELTA 2__
-- __DELTA Pro__
+- __RIVER Max__
+- __RIVER 2__
+- __RIVER 2 Max__
 - __DELTA Max__
+- __DELTA 2__
+- __DELTA 2 Max__
+- __DELTA Pro__
 
 Please, create an issue to let me know if exporter works well (or not) with your model.
 

--- a/ecoflow_exporter.py
+++ b/ecoflow_exporter.py
@@ -275,7 +275,7 @@ class Worker:
         log.debug(f"Processing params: {params}")
         for ecoflow_payload_key in params.keys():
             ecoflow_payload_value = params[ecoflow_payload_key]
-            if isinstance(ecoflow_payload_value, list):
+            if not isinstance(ecoflow_payload_value, (int, float)):
                 log.warning(f"Skipping unsupported metric {ecoflow_payload_key}: {ecoflow_payload_value}")
                 continue
 

--- a/ecoflow_exporter.py
+++ b/ecoflow_exporter.py
@@ -273,8 +273,7 @@ class Worker:
 
     def process_payload(self, params):
         log.debug(f"Processing params: {params}")
-        for ecoflow_payload_key in params.keys():
-            ecoflow_payload_value = params[ecoflow_payload_key]
+        for ecoflow_payload_key, ecoflow_payload_value in params.items():
             if not isinstance(ecoflow_payload_value, (int, float)):
                 log.warning(f"Skipping unsupported metric {ecoflow_payload_key}: {ecoflow_payload_value}")
                 continue

--- a/ecoflow_exporter.py
+++ b/ecoflow_exporter.py
@@ -120,7 +120,7 @@ class EcoflowMQTT():
             self.client.loop_stop()
             self.client.disconnect()
 
-        self.client = mqtt.Client(self.client_id)
+        self.client = mqtt.Client(mqtt.CallbackAPIVersion.VERSION1, self.client_id)
         self.client.username_pw_set(self.username, self.password)
         self.client.tls_set(certfile=None, keyfile=None, cert_reqs=ssl.CERT_REQUIRED)
         self.client.tls_insecure_set(False)

--- a/ecoflow_exporter.py
+++ b/ecoflow_exporter.py
@@ -273,7 +273,8 @@ class Worker:
 
     def process_payload(self, params):
         log.debug(f"Processing params: {params}")
-        for ecoflow_payload_key, ecoflow_payload_value in params.items():
+        for ecoflow_payload_key in params.keys():
+            ecoflow_payload_value = params[ecoflow_payload_key]
             if not isinstance(ecoflow_payload_value, (int, float)):
                 log.warning(f"Skipping unsupported metric {ecoflow_payload_key}: {ecoflow_payload_value}")
                 continue

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 prometheus-client>=0.15.0
-paho-mqtt>=1.6.1
+paho-mqtt>=2.0
 requests>=2.28.1


### PR DESCRIPTION
This fixes the crash that occurs for me with a Delta 2 Max with 2 x Delta 2 Max Smart Extra Battery attached.

I also threw in a fix for this issue with `paho-mqtt`:

```
Traceback (most recent call last):
  File "/ecoflow_exporter.py", line 365, in <module>
    main()
  File "/ecoflow_exporter.py", line 350, in main
    EcoflowMQTT(message_queue, device_sn, auth.mqtt_username, auth.mqtt_password, auth.mqtt_url, auth.mqtt_port, auth.mqtt_client_id, timeout_seconds)
  File "/ecoflow_exporter.py", line 112, in __init__
    self.connect()
  File "/ecoflow_exporter.py", line 123, in connect
    self.client = mqtt.Client(self.client_id)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/paho/mqtt/client.py", line 772, in __init__
    raise ValueError(
ValueError: Unsupported callback API version: version 2.0 added a callback_api_version, see docs/migrations.rst for details
```

@berezhinskiy -- could you cut a new release after this one?  Thanks!